### PR TITLE
Improve issue form automation and submission UX

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-app.yml
+++ b/.github/ISSUE_TEMPLATE/new-app.yml
@@ -64,12 +64,161 @@ body:
     validations:
       required: true
 
-  - type: input
+  - type: dropdown
     id: subcategories
     attributes:
       label: Subcategories
-      description: Enter one or more exact subcategory names, comma-separated, using the registry browser.
-      placeholder: Decentralized Exchanges, DeFi Yield Aggregators
+      description: GitHub issue forms cannot filter this list by category. Choose only subcategories allowed for your selected category; automation will validate the combination.
+      multiple: true
+      options:
+        - AAA Web3 Games
+        - ABI Tools
+        - Account Abstraction (ERC-4337) Bundlers
+        - Analytics Tools
+        - Assemblers
+        - Block Explorers
+        - Blockchain Auditing Companies
+        - Blockchain Interoperability Tools
+        - Blockchain Security Tools
+        - College Blockchain Clubs
+        - Consensus Clients
+        - Creator DAOs
+        - Crypto Exchanges
+        - Crypto Faucets
+        - Crypto News Websites
+        - Crypto Portfolio Dashboards
+        - Crypto Staking Companies
+        - Crypto Tax Tools
+        - Crypto Trading Tools
+        - Custody Solutions
+        - DAO Developer Tools
+        - DAO Project Management Tools
+        - DAO Reputation Tools
+        - Dapp Templates
+        - Data Availability Blockchains
+        - DeFi Yield Aggregators
+        - DeFi Yield Farming Platforms
+        - Debugging Tools
+        - Decentralized CDPs
+        - Decentralized Computing Tools
+        - Decentralized Derivatives
+        - Decentralized Exchanges
+        - Decentralized Gaming Tools
+        - Decentralized Identity Tools
+        - Decentralized Indexes
+        - Decentralized Insurance Dapps
+        - Decentralized Lending Dapps
+        - Decentralized Options
+        - Decentralized Oracles
+        - Decentralized Storage Tools
+        - Decentralized Synthetics
+        - Decentralized VPNs
+        - Decompilers
+        - Development Frameworks
+        - Dissassemblers
+        - ERC-4337 Paymasters
+        - EVM Tools
+        - Embedded Wallets
+        - Ethereum Signature Tools
+        - Execution Clients
+        - Fiat Onramps
+        - Fuzzing Tools
+        - Gaming DAOs
+        - Gaming NFT Marketplaces
+        - Gas Tools
+        - GitHub Open Source Projects
+        - Hardware Wallets
+        - Indexing Tools
+        - Key Management Providers
+        - Layer 1 Blockchains (L1s)
+        - Layer 2 Blockchains
+        - Liquid Staking Platforms
+        - MEV Analytics Tools
+        - MEV Tools
+        - MPC Wallets
+        - Metaverse Tools
+        - Modular Interoperability Tools
+        - Modular Plugins (ERC-6900)
+        - Multisig Wallets
+        - Music NFT Tools
+        - NFT APIs
+        - NFT Allowlist Tools
+        - NFT Analytics Tools
+        - NFT App Templates
+        - NFT Distribution Tools
+        - NFT Fractionalization Tools
+        - NFT Lending Dapps
+        - NFT Marketplaces
+        - NFT Minting Tools
+        - NFT Renting Dapps
+        - NFT Smart Contract Templates
+        - Name Service Tools
+        - Private Credit RWAs
+        - Proof-of-Personhood Tools
+        - Quest-to-Earn Tools
+        - RPC Node Providers
+        - React Tools
+        - Real Estate RWAs
+        - Regenerative Finance Dapps
+        - Relayers
+        - Rollup Frameworks
+        - Rollups-as-a-Service (RaaS)
+        - Shared Sequencers
+        - Sidechains
+        - Smart Contract Accounts
+        - Smart Contract Templates
+        - Smart Contract Tools
+        - Smart Contract Wallets
+        - Social Tokens
+        - Software Wallets
+        - Solidity Developer Tools
+        - Sports NFT Dapps
+        - Static Analysis Tools
+        - Subgraphs
+        - Symbolic Execution Tools
+        - Testnets
+        - Token Gating Tools
+        - Token Management Tools
+        - Token Price APIs
+        - Tokenized bonds RWAs
+        - Tokenized commodities RWAs
+        - Tokenized equities RWAs
+        - Transaction Tools
+        - Venture DAOs
+        - Wallet Connection Tools
+        - Wallet Developer Tools
+        - Wallet SDKs
+        - Wallet Security Tools
+        - Web3 Accelerators
+        - Web3 Achievements
+        - Web3 Authentication Tools
+        - Web3 Bridges
+        - Web3 Consulting Companies
+        - Web3 Creator Tools
+        - Web3 Credential Tools
+        - Web3 Credit Cards
+        - Web3 Credit Scoring Tools
+        - Web3 Data Tools
+        - Web3 Education Resources
+        - Web3 Email Tools
+        - Web3 Fundraising Tools
+        - Web3 Game Studios
+        - Web3 Games
+        - Web3 IDEs
+        - Web3 Languages
+        - Web3 Libraries
+        - Web3 Messaging Tools
+        - Web3 Payment Tools
+        - Web3 Prediction Markets
+        - Web3 SDKs
+        - Web3 Security Competitions
+        - Web3 Social Media Dapps
+        - Web3 Testing Tools
+        - Web3 VC Firms
+        - Webhooks
+        - ZK Developer Tools
+        - ZK Proof Generation Tools
+        - ZK Proving Systems
     validations:
       required: true
 
@@ -199,17 +348,35 @@ body:
     id: logo
     attributes:
       label: Logo URL
-      description: Public image URL, or describe where the logo can be found.
+      description: Optional if you upload a logo below. Public image URL is preferred when available.
       placeholder: https://example.com/logo.png
     validations:
-      required: true
+      required: false
+
+  - type: upload
+    id: logo_upload
+    attributes:
+      label: Logo upload
+      description: Optional if you already provided a Logo URL. Upload a PNG, JPG, SVG, or WebP file.
+    validations:
+      required: false
+      accept: ".png,.jpg,.jpeg,.svg,.webp"
+
+  - type: textarea
+    id: alternative_apps
+    attributes:
+      label: Alternative apps
+      description: Optional. Provide exact slugs, comma-separated or one per line.
+      placeholder: uniswap, 1inch, cow-swap
+    validations:
+      required: false
 
   - type: textarea
     id: related_apps
     attributes:
-      label: Related or alternative apps
-      description: Optional. Provide known slugs if you know them, comma-separated.
-      placeholder: uniswap, 1inch, cow-swap
+      label: Related apps
+      description: Optional. Provide exact slugs, comma-separated or one per line.
+      placeholder: aave, safe, walletconnect
     validations:
       required: false
 

--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   new_app_issue_to_pr:
     # Only `new-app` submissions are automated. Taxonomy and chain registry requests stay manual.
-    if: contains(github.event.issue.labels.*.name, 'new-app')
+    if: startsWith(github.event.issue.title, '[New App]:') && contains(github.event.issue.body, '### App name')
     runs-on: ubuntu-latest
 
     steps:

--- a/scripts/create-new-app-from-issue.ts
+++ b/scripts/create-new-app-from-issue.ts
@@ -90,6 +90,14 @@ function parseCommaSeparatedList(value: string): string[] {
     .filter(Boolean);
 }
 
+function parseMultiValueList(value: string): string[] {
+  return normalizeFieldValue(value)
+    .split("\n")
+    .flatMap((line) => line.split(","))
+    .map((item) => item.replace(/^-\s+(?:\[[x ]\]\s+)?/i, "").trim())
+    .filter(Boolean);
+}
+
 function loadRegistries(baseDir: string = process.cwd()): Registries {
   const taxonomyPath = path.join(baseDir, "data", "taxonomy.json");
   const chainsPath = path.join(baseDir, "data", "chains.json");
@@ -116,6 +124,21 @@ function parseCheckedValues(value: string): string[] {
     .map((line) => line.trim())
     .filter((line) => /^-\s+\[x\]\s+/i.test(line))
     .map((line) => line.replace(/^-\s+\[x\]\s+/i, "").trim());
+}
+
+function parseUploadedAssetUrl(value: string): string | undefined {
+  const normalized = normalizeFieldValue(value);
+  if (!normalized) {
+    return undefined;
+  }
+
+  const markdownLinkMatch = normalized.match(/\((https?:\/\/[^)\s]+)\)/);
+  if (markdownLinkMatch?.[1]) {
+    return markdownLinkMatch[1];
+  }
+
+  const rawUrlMatch = normalized.match(/https?:\/\/\S+/);
+  return rawUrlMatch?.[0];
 }
 
 function truncateText(value: string, limit: number): string {
@@ -169,11 +192,16 @@ export function buildNewAppMetaFromIssue(
     200,
   );
   const fullDescription = getRequiredField(sections, "Full description");
-  const logoUrl = getRequiredField(sections, "Logo URL");
+  const logoUrl =
+    getOptionalField(sections, "Logo URL") ??
+    parseUploadedAssetUrl(sections["Logo upload"] ?? "");
+  if (!logoUrl) {
+    throw new Error('Issue form must include either "Logo URL" or "Logo upload".');
+  }
   const website = getRequiredField(sections, "Website URL");
   const pricingInput = getRequiredField(sections, "Pricing");
   const pricing = pricingInput === "Not sure" ? "" : pricingInput;
-  const subcategory = parseCommaSeparatedList(
+  const subcategory = parseMultiValueList(
     getRequiredField(sections, "Subcategories"),
   );
   const chains = parseCheckedValues(sections["Chains"] ?? "");
@@ -209,14 +237,27 @@ export function buildNewAppMetaFromIssue(
     }
   }
 
-  const relatedAppCandidates = parseCommaSeparatedList(
-    sections["Related or alternative apps"] ?? "",
+  const alternativeCandidates = parseMultiValueList(
+    sections["Alternative apps"] ?? "",
   );
+  const relatedCandidates = parseMultiValueList(sections["Related apps"] ?? "");
   const existingSlugSet = new Set(existingSlugs);
-  const alternatives = relatedAppCandidates.filter((candidate) =>
+  const alternatives = alternativeCandidates.filter((candidate) =>
     existingSlugSet.has(candidate),
   );
-  const unknownRelatedApps = relatedAppCandidates.filter(
+  const unknownAlternatives = alternativeCandidates.filter(
+    (candidate) => !existingSlugSet.has(candidate),
+  );
+  if (unknownAlternatives.length > 0) {
+    warnings.push(
+      `Ignored alternatives without matching slugs: ${unknownAlternatives.join(", ")}`,
+    );
+  }
+
+  const related = relatedCandidates.filter((candidate) =>
+    existingSlugSet.has(candidate),
+  );
+  const unknownRelatedApps = relatedCandidates.filter(
     (candidate) => !existingSlugSet.has(candidate),
   );
   if (unknownRelatedApps.length > 0) {
@@ -256,7 +297,7 @@ export function buildNewAppMetaFromIssue(
       },
       relations: {
         alternatives,
-        related: [],
+        related,
       },
     },
     warnings,

--- a/tests/create-new-app-from-issue.test.ts
+++ b/tests/create-new-app-from-issue.test.ts
@@ -30,7 +30,8 @@ sample-swap
 DeFi Dapps
 
 ### Subcategories
-Decentralized Exchanges, DeFi Yield Aggregators
+Decentralized Exchanges
+DeFi Yield Aggregators
 
 ### Chains
 - [x] Ethereum
@@ -70,8 +71,14 @@ Sample Swap is a decentralized exchange built for fast token swaps and yield rou
 ### Logo URL
 https://sampleswap.xyz/logo.png
 
-### Related or alternative apps
+### Logo upload
+_No response_
+
+### Alternative apps
 uniswap, missing-slug, 1inch
+
+### Related apps
+aave, missing-related
 
 ### Maintainer notes
 No additional notes.
@@ -93,6 +100,7 @@ No additional notes.
     const { meta, warnings } = buildNewAppMetaFromIssue(issueBody, [
       "uniswap",
       "1inch",
+      "aave",
     ], registries);
 
     expect(meta.slug).toBe("sample-swap");
@@ -112,13 +120,14 @@ No additional notes.
     expect(meta.links.telegram).toBe("https://t.me/sampleswap");
     expect(meta.links.discord).toBe("https://discord.gg/sampleswap");
     expect(meta.relations.alternatives).toEqual(["uniswap", "1inch"]);
-    expect(meta.relations.related).toEqual([]);
+    expect(meta.relations.related).toEqual(["aave"]);
     expect(meta.content.pageTitle).toBe(
       "Sample Swap - DeFi Dapps - Lancers Web3 Explorer",
     );
     expect(meta.content.meta.length).toBeLessThanOrEqual(200);
     expect(warnings).toEqual([
-      "Ignored related apps without matching slugs: missing-slug",
+      "Ignored alternatives without matching slugs: missing-slug",
+      "Ignored related apps without matching slugs: missing-related",
     ]);
   });
 
@@ -159,6 +168,22 @@ No additional notes.
 
     expect(() => buildNewAppMetaFromIssue(invalidBody, [], registries)).toThrow(
       'Chain "FakeChain" is not in the chain registry.',
+    );
+  });
+
+  it("uses the uploaded logo URL when the direct logo URL field is empty", () => {
+    const uploadedLogoBody = issueBody.replace(
+      "### Logo URL\nhttps://sampleswap.xyz/logo.png",
+      "### Logo URL\n_No response_",
+    ).replace(
+      "### Logo upload\n_No response_",
+      "### Logo upload\n![sample-swap-logo](https://github.com/user-attachments/assets/sample-swap-logo.png)",
+    );
+
+    const { meta } = buildNewAppMetaFromIssue(uploadedLogoBody, [], registries);
+
+    expect(meta.logoUrl).toBe(
+      "https://github.com/user-attachments/assets/sample-swap-logo.png",
     );
   });
 });


### PR DESCRIPTION
## Summary
- remove the draft-PR workflow's dependency on the `new-app` label and key automation off the new-app issue form instead
- update the new app issue form to use multi-select subcategories, split `Alternative apps` and `Related apps`, and allow logo upload as an alternative to a logo URL
- extend the issue parser to support uploaded logo URLs and the new relation fields while preserving registry validation
- add parser test coverage for the new form shape and uploaded-logo fallback

## Testing
- `pnpm test -- tests/create-new-app-from-issue.test.ts`
- `pnpm run dev:validate`
- YAML parse check for `.github/ISSUE_TEMPLATE/new-app.yml` and `.github/workflows/issue-to-pr.yml`