### PR TITLE
Fix issue-to-PR automation skipping and failing submissions

### DIFF
--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -5,6 +5,10 @@ on:
     types:
       - opened
       - reopened
+      # `edited` so a submission that failed on a fixable mistake (wrong
+      # subcategory, missing field) retries once the author corrects it,
+      # instead of needing a maintainer to close and reopen the issue.
+      - edited
 
 permissions:
   contents: write
@@ -18,7 +22,14 @@ concurrency:
 jobs:
   new_app_issue_to_pr:
     # Only `new-app` submissions are automated. Taxonomy and chain registry requests stay manual.
-    if: startsWith(github.event.issue.title, '[New App]:') && contains(github.event.issue.body, '### App name')
+    #
+    # Gate on the label, not the title. The issue form prefills the title as
+    # "[New App]: " but GitHub lets the submitter overwrite it, and several have
+    # (#120 became "[CiaoTool]: ..."). A renamed title skipped this job before any
+    # step ran, so no PR was opened and no failure comment was posted -- the
+    # submission simply vanished. The `new-app` label is applied by the form and
+    # cannot be edited by the submitter, so it is the reliable signal.
+    if: contains(github.event.issue.labels.*.name, 'new-app') && contains(github.event.issue.body, '### App name')
     runs-on: ubuntu-latest
 
     steps:
@@ -50,7 +61,7 @@ jobs:
         if: steps.generate.outcome == 'success'
         continue-on-error: true
         run: |
-          pnpm run dev:validate >"$RUNNER_TEMP/validate.log" 2>&1
+          pnpm run validate >"$RUNNER_TEMP/validate.log" 2>&1
 
       - name: Create draft pull request
         id: cpr

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,9 @@ Lancers Dapp Registry is a curated Web3 application registry with structured met
 
 ```bash
 pnpm install                    # Install dependencies
-pnpm run dev:validate           # Validate all meta.json files against schema
-pnpm run dev:distill            # Generate apps.min.json and facets.index.json
-pnpm run dev:build:site         # Build publishable site bundle to build/
+pnpm run validate           # Validate all meta.json files against schema
+pnpm run distill            # Generate apps.min.json and facets.index.json
+pnpm run build:site         # Build publishable site bundle to build/
 pnpm test                       # Run Jest tests
 pnpm test -- tests/validate.test.ts  # Run single test file
 ```
@@ -60,4 +60,4 @@ The `metaJsonSchema` in `schema/metaJsonSchema.ts` defines required fields:
 1. Create/edit `src/apps/<slug>/meta.json`
 2. Ensure `slug` matches folder name exactly
 3. Ensure all relations reference existing slugs
-4. Run `pnpm run dev:validate` before committing
+4. Run `pnpm run validate` before committing


### PR DESCRIPTION
Two independent faults stopped new-app issues becoming draft PRs.

The job was gated on the issue title starting with "[New App]:". That prefix is only a prefill in the issue form and submitters can overwrite it, which several did (#120 became "[CiaoTool]: ..."). A renamed title skipped the job before any step ran, so no PR was opened and no failure comment posted either, since the reporting steps live inside the same job. The submission just disappeared. Gating on the `new-app` label instead is reliable, because the form applies it and the submitter cannot change it.

Separately, the validate step ran `pnpm run dev:validate`, which is not a defined script; only `validate` exists. pnpm exited with ERR_PNPM_NO_SCRIPT, and because opening the PR requires the validate step to have succeeded, no PR was created even when the metadata generated cleanly (#121). CLAUDE.md documented the same three non-existent `dev:` commands, which is where the typo came from, so those are corrected too.

Also adds the `edited` trigger, so a submission rejected for something the author can fix retries when they edit the issue rather than needing a maintainer to close and reopen it.